### PR TITLE
Fix dark theme in production

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -48,7 +48,7 @@ const config = {
           //   'https://github.com/ShopBonsai/docs/tree/main/',
         },
         theme: {
-          customCss: require.resolve('./src/css/custom.css'),
+          customCss: [require.resolve('./src/css/custom.css')],
         },
       }),
     ],

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -18,7 +18,7 @@
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
-[data-theme='dark'] {
+[data-theme='dark']:root {
   --ifm-color-primary: #fc5033;
   --ifm-color-primary-dark: #fc3615;
   --ifm-color-primary-darker: #fb2a06;


### PR DESCRIPTION
Dark theme doesn't display Bonsai branded colours in production.
<img width="1073" alt="image" src="https://user-images.githubusercontent.com/10702288/216395932-ac254c18-2e67-4b16-8d70-328d78ed9371.png">

To test the fix 
- Run `yarn build`
- Run `yarn serve`
- It should display orange instead of dark blue
<img width="1082" alt="image" src="https://user-images.githubusercontent.com/10702288/216396170-62e5fa11-8d07-4538-af94-d551f5bd8cce.png">
